### PR TITLE
Fix contracting views inheritance

### DIFF
--- a/openprocurement/auctions/insider/views/contract.py
+++ b/openprocurement/auctions/insider/views/contract.py
@@ -3,15 +3,17 @@
 from openprocurement.auctions.core.utils import (
     opresource,
 )
-from openprocurement.auctions.dgf.views.financial.contract import (
-    FinancialAuctionAwardContractResource,
+from openprocurement.auctions.core.contracting.dgf.views.contract import (
+    BaseAuctionAwardContractResource
 )
 
 
-@opresource(name='dgfInsider:Auction Contracts',
-            collection_path='/auctions/{auction_id}/contracts',
-            path='/auctions/{auction_id}/contracts/{contract_id}',
-            auctionsprocurementMethodType="dgfInsider",
-            description="Insider auction contracts")
-class InsiderAuctionAwardContractResource(FinancialAuctionAwardContractResource):
+@opresource(
+    name='dgfInsider:Auction Contracts',
+    collection_path='/auctions/{auction_id}/contracts',
+    path='/auctions/{auction_id}/contracts/{contract_id}',
+    auctionsprocurementMethodType="dgfInsider",
+    description="Insider auction contracts"
+)
+class InsiderAuctionAwardContractResource(BaseAuctionAwardContractResource):
     pass

--- a/openprocurement/auctions/insider/views/contract_document.py
+++ b/openprocurement/auctions/insider/views/contract_document.py
@@ -3,15 +3,20 @@
 from openprocurement.auctions.core.utils import (
     opresource,
 )
-from openprocurement.auctions.dgf.views.financial.contract_document import (
-    FinancialAuctionAwardContractDocumentResource,
+from openprocurement.auctions.core.contracting.dgf.views.\
+    contract_document import (
+    BaseAuctionAwardContractDocumentResource
 )
 
 
-@opresource(name='dgfInsider:Auction Contract Documents',
-            collection_path='/auctions/{auction_id}/contracts/{contract_id}/documents',
-            path='/auctions/{auction_id}/contracts/{contract_id}/documents/{document_id}',
-            auctionsprocurementMethodType="dgfInsider",
-            description="Insider auction contract documents")
-class InsiderAuctionAwardContractDocumentResource(FinancialAuctionAwardContractDocumentResource):
+@opresource(
+    name='dgfInsider:Auction Contract Documents',
+    collection_path='/auctions/{auction_id}/contracts/{contract_id}/documents',
+    path='/auctions/{auction_id}/contracts/{contract_id}/documents/{document_id}',
+    auctionsprocurementMethodType="dgfInsider",
+    description="Insider auction contract documents"
+)
+class InsiderAuctionAwardContractDocumentResource(
+    BaseAuctionAwardContractDocumentResource
+):
     pass


### PR DESCRIPTION
Contracting views were inherited from
`openprocurement.auctions.dgf.views.financial.contract.FinancialAuctionAwardContractResource`,
but their parent-classes were extracted to
`openprocurement.auction.core.contracting.dgf.views`.
So now they're inherited from extracted ones.