### PR TITLE
Remove api dependencies

### DIFF
--- a/docs.py
+++ b/docs.py
@@ -5,12 +5,17 @@ from datetime import timedelta, datetime
 from uuid import uuid4
 from copy import deepcopy
 
-from openprocurement.api.utils import get_now
-import openprocurement.auctions.insider.tests.base as base_test
-from openprocurement.auctions.dgf.tests.base import base_test_bids, test_financial_organization
-from openprocurement.auctions.flash.tests.base import PrefixedRequestClass
-from openprocurement.auctions.insider.tests.base import test_insider_auction_data as base_test_auction_data, BaseInsiderAuctionWebTest, test_procuringEntity
 from webtest import TestApp
+
+from openprocurement.auctions.core.utils import get_now
+
+from openprocurement.auctions.flash.tests.base import PrefixedRequestClass
+
+from openprocurement.auctions.dgf.tests.base import base_test_bids, test_financial_organization
+
+import openprocurement.auctions.insider.tests.base as base_test
+from openprocurement.auctions.insider.tests.base import test_insider_auction_data as base_test_auction_data, BaseInsiderAuctionWebTest, test_procuringEntity
+
 
 now = datetime.now()
 

--- a/openprocurement/auctions/insider/includeme.py
+++ b/openprocurement/auctions/insider/includeme.py
@@ -1,5 +1,7 @@
 from pyramid.interfaces import IRequest
-from openprocurement.api.interfaces import IContentConfigurator
+
+from openprocurement.auctions.core.includeme import IContentConfigurator
+
 from openprocurement.auctions.insider.models import DGFInsider, IInsiderAuction
 from openprocurement.auctions.insider.adapters import AuctionInsiderConfigurator
 from openprocurement.auctions.insider.constants import VIEW_LOCATIONS

--- a/openprocurement/auctions/insider/migration.py
+++ b/openprocurement/auctions/insider/migration.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from openprocurement.api.utils import get_now
-
 from openprocurement.auctions.core.plugins.awarding.v3.migration import (
     migrate_awarding2_to_awarding3
 )
 from openprocurement.auctions.core.traversal import Root
+from openprocurement.auctions.core.utils import get_now
 
 
 LOGGER = logging.getLogger(__name__)

--- a/openprocurement/auctions/insider/models.py
+++ b/openprocurement/auctions/insider/models.py
@@ -8,26 +8,24 @@ from schematics.types.compound import ModelType
 from schematics.types.serializable import serializable
 from zope.interface import implementer
 
-from openprocurement.api.constants import (
-    SANDBOX_MODE,
-    AUCTIONS_COMPLAINT_STAND_STILL_TIME,
-    TZ
-)
-from openprocurement.api.models.auction_models.models import (
+from openprocurement.auctions.core.constants import DGF_PLATFORM_LEGAL_DETAILS
+from openprocurement.auctions.core.models import (
     Model,
     ListType,
     Value,
     Period,
-)
-from openprocurement.api.utils import calculate_business_date, get_now
-
-from openprocurement.auctions.core.constants import DGF_PLATFORM_LEGAL_DETAILS
-from openprocurement.auctions.core.models import (
     IAuction,
     get_auction,
     dgfOrganization as Organization
 )
-from openprocurement.auctions.core.utils import rounding_shouldStartAfter_after_midnigth
+from openprocurement.auctions.core.utils import (
+    rounding_shouldStartAfter_after_midnigth,
+    AUCTIONS_COMPLAINT_STAND_STILL_TIME,
+    calculate_business_date,
+    SANDBOX_MODE,
+    get_now,
+    TZ,
+)
 
 from openprocurement.auctions.dgf.models import (
     DGFFinancialAssets as BaseAuction,
@@ -177,7 +175,7 @@ class Auction(BaseAuction):
             if standStillEnds and last_award_status == 'unsuccessful':
                 checks.append(max(standStillEnds))
         if self.status.startswith('active'):
-            from openprocurement.api.utils import calculate_business_date
+            from openprocurement.auctions.core.utils import calculate_business_date
             for complaint in self.complaints:
                 if complaint.status == 'claim' and complaint.dateSubmitted:
                     checks.append(calculate_business_date(complaint.dateSubmitted, AUCTIONS_COMPLAINT_STAND_STILL_TIME, self))

--- a/openprocurement/auctions/insider/tests/award.py
+++ b/openprocurement/auctions/insider/tests/award.py
@@ -3,8 +3,6 @@ import unittest
 
 from datetime import timedelta
 
-from openprocurement.api.utils import get_now
-
 from openprocurement.auctions.core.tests.award import (
     AuctionAwardDocumentResourceTestMixin
 )
@@ -12,6 +10,7 @@ from openprocurement.auctions.core.plugins.awarding.v3.tests.award import (
     AuctionAwardProcessTestMixin,
     CreateAuctionAwardTestMixin
 )
+from openprocurement.auctions.core.utils import get_now
 
 from openprocurement.auctions.insider.tests.base import (
     BaseInsiderAuctionWebTest,

--- a/openprocurement/auctions/insider/tests/base.py
+++ b/openprocurement/auctions/insider/tests/base.py
@@ -3,7 +3,8 @@ import os
 from datetime import datetime, timedelta
 from copy import deepcopy
 
-from openprocurement.api.utils import apply_data_patch
+from openprocurement.auctions.core.utils import apply_data_patch
+
 from openprocurement.auctions.dgf.tests.base import (
     BaseWebTest,
     BaseFinancialAuctionWebTest,

--- a/openprocurement/auctions/insider/tests/blanks/auction_blanks.py
+++ b/openprocurement/auctions/insider/tests/blanks/auction_blanks.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from datetime import timedelta
-from openprocurement.api.utils import get_now
+
+from openprocurement.auctions.core.utils import get_now
 
 # InsiderAuctionAuctionResourceTest
 

--- a/openprocurement/auctions/insider/tests/blanks/bidder_blanks.py
+++ b/openprocurement/auctions/insider/tests/blanks/bidder_blanks.py
@@ -2,7 +2,8 @@
 from urllib import unquote
 from base64 import b64decode
 from libnacl.sign import Signer, Verifier
-from openprocurement.api.tests.base import JSON_RENDERER_ERROR
+
+from openprocurement.auctions.core.tests.base import JSON_RENDERER_ERROR
 
 # InsiderAuctionBidderResourceTest
 

--- a/openprocurement/auctions/insider/tests/blanks/chronograph_blanks.py
+++ b/openprocurement/auctions/insider/tests/blanks/chronograph_blanks.py
@@ -1,4 +1,5 @@
-from openprocurement.api.utils import get_now
+# -*- coding: utf-8 -*-
+from openprocurement.auctions.core.utils import get_now
 
 # InsiderAuctionAuctionPeriodResourceTest
 

--- a/openprocurement/auctions/insider/tests/blanks/tender_blanks.py
+++ b/openprocurement/auctions/insider/tests/blanks/tender_blanks.py
@@ -3,9 +3,10 @@ from copy import deepcopy
 from datetime import timedelta
 from iso8601 import parse_date
 
-from openprocurement.api.constants import SANDBOX_MODE, TZ
-from openprocurement.api.utils import get_now
-from openprocurement.api.tests.base import JSON_RENDERER_ERROR
+from openprocurement.auctions.core.tests.base import JSON_RENDERER_ERROR
+from openprocurement.auctions.core.utils import (
+    SANDBOX_MODE, TZ, get_now
+)
 
 # InsiderAuctionTest
 

--- a/openprocurement/auctions/insider/tests/chronograph.py
+++ b/openprocurement/auctions/insider/tests/chronograph.py
@@ -2,10 +2,6 @@
 import unittest
 from datetime import timedelta
 
-from openprocurement.api.utils import get_now
-from openprocurement.auctions.insider.tests.base import (
-    BaseInsiderAuctionWebTest, test_financial_bids,
-)
 from openprocurement.auctions.core.tests.base import snitch
 from openprocurement.auctions.core.tests.blanks.chronograph_blanks import (
     # InsiderAuctionSwitchAuctionResourceTest
@@ -22,8 +18,11 @@ from openprocurement.auctions.core.plugins.awarding.v3.tests.blanks.chronograph_
     switch_verification_to_unsuccessful_2,
     switch_active_to_unsuccessful_2,
 )
+from openprocurement.auctions.core.utils import get_now
 
-
+from openprocurement.auctions.insider.tests.base import (
+    BaseInsiderAuctionWebTest, test_financial_bids,
+)
 from openprocurement.auctions.insider.tests.blanks.chronograph_blanks import (
     # InsiderAuctionAuctionPeriodResourceTest
     set_auction_period,

--- a/openprocurement/auctions/insider/tests/contract.py
+++ b/openprocurement/auctions/insider/tests/contract.py
@@ -2,18 +2,17 @@
 import unittest
 from datetime import timedelta
 
-from openprocurement.api.utils import get_now
-from openprocurement.auctions.insider.tests.base import (
-    BaseInsiderAuctionWebTest, test_financial_bids,
-    test_insider_auction_data, test_financial_organization,
-)
-from openprocurement.auctions.core.tests.base import snitch
 from openprocurement.auctions.core.tests.contract import (
     AuctionContractResourceTestMixin,
     AuctionContractDocumentResourceTestMixin
 )
 from openprocurement.auctions.core.plugins.contracting.v3.tests.contract import (
     AuctionContractV3ResourceTestCaseMixin
+)
+from openprocurement.auctions.core.utils import get_now
+
+from openprocurement.auctions.insider.tests.base import (
+    BaseInsiderAuctionWebTest, test_financial_bids,
 )
 
 

--- a/openprocurement/auctions/insider/utils.py
+++ b/openprocurement/auctions/insider/utils.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 from logging import getLogger
 from pkg_resources import get_distribution
-from openprocurement.api.utils import get_now
-from openprocurement.api.constants import TZ
-from openprocurement.api.utils import context_unpack
 
+from openprocurement.auctions.core.utils import (
+    context_unpack,
+    get_now,
+    TZ,
+)
 from openprocurement.auctions.core.models import AUCTION_STAND_STILL_TIME
+
 from openprocurement.auctions.insider.constants import (
     STAGE_TIMEDELTA,
-    SERVICE_TIMEDELTA,
     BESTBID_TIMEDELTA,
     SEALEDBID_TIMEDELTA,
     SERVICE_TIMEDELTA

--- a/openprocurement/auctions/insider/validation.py
+++ b/openprocurement/auctions/insider/validation.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-from openprocurement.api.utils import get_now
-
+from openprocurement.auctions.core.utils import get_now
 from openprocurement.auctions.core.validation import (
     validate_patch_auction_data,
 )

--- a/openprocurement/auctions/insider/views/auction.py
+++ b/openprocurement/auctions/insider/views/auction.py
@@ -1,21 +1,21 @@
 # -*- coding: utf-8 -*-
-from openprocurement.api.utils import (
-    json_view,
-    context_unpack,
-)
 from openprocurement.auctions.core.utils import (
-    save_auction,
     apply_patch,
+    context_unpack,
+    json_view,
     opresource,
-    remove_draft_bids
+    remove_draft_bids,
+    save_auction,
 )
-from openprocurement.auctions.insider.validation import (
-    validate_auction_auction_data,
-)
+
 from openprocurement.auctions.dgf.views.financial.auction import (
     FinancialAuctionAuctionResource,
 )
+
 from openprocurement.auctions.insider.utils import invalidate_empty_bids, merge_auction_results
+from openprocurement.auctions.insider.validation import (
+    validate_auction_auction_data,
+)
 
 
 @opresource(name='dgfInsider:Auction Auction',

--- a/openprocurement/auctions/insider/views/bid.py
+++ b/openprocurement/auctions/insider/views/bid.py
@@ -1,22 +1,21 @@
 # -*- coding: utf-8 -*-
-
 from openprocurement.auctions.core.utils import (
-    opresource,
     apply_patch,
+    context_unpack,
+    get_now,
+    json_view,
+    opresource,
     save_auction,
+    set_ownership,
 )
+from openprocurement.auctions.core.validation import validate_bid_data, validate_patch_bid_data
+
 from openprocurement.auctions.dgf.views.financial.bid import (
     FinancialAuctionBidResource,
 )
 
-from openprocurement.api.utils import (
-    json_view,
-    context_unpack,
-    set_ownership
-)
-from openprocurement.api.utils import get_now
-from openprocurement.auctions.core.validation import validate_bid_data, validate_patch_bid_data
 from openprocurement.auctions.insider.constants import TENDER_PERIOD_STATUSES
+
 
 @opresource(name='dgfInsider:Auction Bids',
             collection_path='/auctions/{auction_id}/bids',

--- a/openprocurement/auctions/insider/views/bid_document.py
+++ b/openprocurement/auctions/insider/views/bid_document.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-from openprocurement.api.utils import get_now
 from openprocurement.auctions.core.utils import (
+    get_now,
     opresource,
 )
+
 from openprocurement.auctions.dgf.views.financial.bid_document import (
     FinancialAuctionBidDocumentResource,
 )
+
 from openprocurement.auctions.insider.constants import TENDER_PERIOD_STATUSES
 
 

--- a/openprocurement/auctions/insider/views/tender.py
+++ b/openprocurement/auctions/insider/views/tender.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
-from openprocurement.api.utils import (
-    context_unpack,
-    json_view,
-)
 from openprocurement.auctions.core.utils import (
     apply_patch,
+    context_unpack,
+    json_view,
     opresource,
     save_auction,
 )
 from openprocurement.auctions.core.validation import (
     validate_patch_auction_data,
 )
+
 from openprocurement.auctions.dgf.views.financial.tender import FinancialAuctionResource
+
 from openprocurement.auctions.insider.utils import check_status
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ entry_points = {
 
 requires = [
     'setuptools',
-    'openprocurement.api',
     'openprocurement.auctions.core',
     'openprocurement.auctions.flash',
     'openprocurement.auctions.dgf',


### PR DESCRIPTION
### Depends on:
- openprocurement/openprocurement.api#287
- openprocurement/openprocurement.auctions.core#78
- https://github.com/openprocurement/openprocurement.auctions.dgf/pull/92

Remove api dependencies