### PR TITLE
Fix procurementMethoType and add documentservice to test

### DIFF
--- a/openprocurement/auctions/insider/constants.py
+++ b/openprocurement/auctions/insider/constants.py
@@ -18,4 +18,4 @@ VIEW_LOCATIONS = [
     "openprocurement.auctions.insider.views",
 ]
 
-DEFAULT_PROCUREMENT_METHOD_TYPE = "exampleDGFInsider"
+DEFAULT_PROCUREMENT_METHOD_TYPE = "DGFInsider"

--- a/openprocurement/auctions/insider/tests/contract.py
+++ b/openprocurement/auctions/insider/tests/contract.py
@@ -84,6 +84,7 @@ class InsiderAuctionContractDocumentResourceTest(BaseInsiderAuctionWebTest, Auct
     #initial_data = auction_data
     initial_status = 'active.auction'
     initial_bids = test_bids
+    docservice = True
 
     def setUp(self):
         super(InsiderAuctionContractDocumentResourceTest, self).setUp()


### PR DESCRIPTION
Залежить від https://github.com/openprocurement/openprocurement.auctions.core/pull/103