### PR TITLE
A734478612480132 remove admins token

### DIFF
--- a/openprocurement/auctions/insider/tests/award.py
+++ b/openprocurement/auctions/insider/tests/award.py
@@ -19,7 +19,7 @@ from openprocurement.auctions.insider.tests.base import (
 
 
 class InsiderAuctionCreateAwardTest(BaseInsiderAuctionWebTest, CreateAuctionAwardTestMixin):
-    initial_status = 'active.qualification'
+    initial_status = 'active.auction'
     initial_bids = test_bids
 
 
@@ -86,7 +86,6 @@ class InsiderAuctionAwardProcessTest(BaseInsiderAuctionWebTest, AuctionAwardProc
 
         authorization = self.app.authorization
         self.app.authorization = ('Basic', ('auction', ''))
-        now = get_now()
         response = self.app.get('/auctions/{}'.format(self.auction_id))
         self.assertEqual(response.status, '200 OK')
         auction = response.json['data']

--- a/openprocurement/auctions/insider/tests/blanks/auction_blanks.py
+++ b/openprocurement/auctions/insider/tests/blanks/auction_blanks.py
@@ -7,6 +7,7 @@ from openprocurement.auctions.core.utils import get_now
 
 
 def get_auction_auction(self):
+    self.app.authorization = ('Basic', ('auction', ''))
     response = self.app.get('/auctions/{}/auction'.format(self.auction_id))
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')

--- a/openprocurement/auctions/insider/tests/cancellation.py
+++ b/openprocurement/auctions/insider/tests/cancellation.py
@@ -22,8 +22,9 @@ class InsiderAuctionCancellationDocumentResourceTest(BaseInsiderAuctionWebTest,
     def setUp(self):
         super(InsiderAuctionCancellationDocumentResourceTest, self).setUp()
         # Create cancellation
-        response = self.app.post_json('/auctions/{}/cancellations'.format(
-            self.auction_id), {'data': {'reason': 'cancellation reason'}})
+        response = self.app.post_json('/auctions/{}/cancellations?acc_token={}'.format(
+            self.auction_id, self.auction_token
+        ), {'data': {'reason': 'cancellation reason'}})
         cancellation = response.json['data']
         self.cancellation_id = cancellation['id']
 

--- a/openprocurement/auctions/insider/tests/complaint.py
+++ b/openprocurement/auctions/insider/tests/complaint.py
@@ -7,18 +7,24 @@ from openprocurement.auctions.core.tests.complaint import (
     InsiderAuctionComplaintDocumentResourceTestMixin
 )
 
-
+@unittest.skip("option not available")
 class InsiderAuctionComplaintResourceTest(BaseInsiderAuctionWebTest, AuctionComplaintResourceTestMixin):
     """Test Case for Auction Complaint resource"""
 
 
+@unittest.skip("option not available")
 class InsiderAuctionComplaintDocumentResourceTest(BaseInsiderAuctionWebTest, InsiderAuctionComplaintDocumentResourceTestMixin):
 
     def setUp(self):
         super(InsiderAuctionComplaintDocumentResourceTest, self).setUp()
         # Create complaint
         response = self.app.post_json('/auctions/{}/complaints'.format(
-            self.auction_id), {'data': {'title': 'complaint title', 'description': 'complaint description', 'author': self.initial_organization}})
+            self.auction_id
+        ), {'data': {
+                'title': 'complaint title',
+                'description': 'complaint description',
+                'author': self.initial_organization
+        }})
         complaint = response.json['data']
         self.complaint_id = complaint['id']
         self.complaint_owner_token = response.json['access']['token']

--- a/openprocurement/auctions/insider/tests/contract.py
+++ b/openprocurement/auctions/insider/tests/contract.py
@@ -58,7 +58,6 @@ class InsiderAuctionContractResourceTest(
 
         self.set_status('active.qualification')
 
-        self.app.authorization = ('Basic', ('token', ''))
         response = self.app.post('/auctions/{}/awards/{}/documents?acc_token={}'.format(
             self.auction_id, self.award_id, self.auction_token), upload_files=[('file', 'auction_protocol.pdf', 'content')])
         self.assertEqual(response.status, '201 Created')
@@ -74,7 +73,9 @@ class InsiderAuctionContractResourceTest(
         self.assertEqual(response.json["data"]["documentType"], 'auctionProtocol')
         self.assertEqual(response.json["data"]["author"], 'auction_owner')
 
-        self.app.patch_json('/auctions/{}/awards/{}'.format(self.auction_id, self.award_id), {"data": {"status": "active"}})
+        self.app.patch_json('/auctions/{}/awards/{}?acc_token={}'.format(
+            self.auction_id, self.award_id, self.auction_token
+        ), {"data": {"status": "active"}})
         response = self.app.get('/auctions/{}'.format(self.auction_id))
         auction = response.json['data']
         self.award_contract_id = auction['contracts'][0]['id']
@@ -120,7 +121,6 @@ class InsiderAuctionContractDocumentResourceTest(BaseInsiderAuctionWebTest, Auct
 
         self.set_status('active.qualification')
 
-        self.app.authorization = ('Basic', ('token', ''))
         response = self.app.post('/auctions/{}/awards/{}/documents?acc_token={}'.format(
             self.auction_id, self.award_id, self.auction_token), upload_files=[('file', 'auction_protocol.pdf', 'content')])
         self.assertEqual(response.status, '201 Created')
@@ -136,10 +136,12 @@ class InsiderAuctionContractDocumentResourceTest(BaseInsiderAuctionWebTest, Auct
         self.assertEqual(response.json["data"]["documentType"], 'auctionProtocol')
         self.assertEqual(response.json["data"]["author"], 'auction_owner')
 
-        self.app.patch_json('/auctions/{}/awards/{}'.format(self.auction_id, self.award_id), {"data": {"status": "active"}})
-        # Create contract for award
-        response = self.app.post_json('/auctions/{}/contracts'.format(self.auction_id), {'data': {'title': 'contract title', 'description': 'contract description', 'awardID': self.award_id}})
-        contract = response.json['data']
+        self.app.patch_json('/auctions/{}/awards/{}?acc_token={}'.format(
+            self.auction_id, self.award_id, self.auction_token
+        ), {"data": {"status": "active"}})
+        # Getting contract for award
+        response = self.app.get('/auctions/{}/contracts'.format(self.auction_id))
+        contract = response.json['data'][0]
         self.contract_id = contract['id']
 
 

--- a/openprocurement/auctions/insider/tests/migration.py
+++ b/openprocurement/auctions/insider/tests/migration.py
@@ -92,13 +92,15 @@ class MigrateTestFrom2To3Schema(BaseInsiderAuctionWebTest):
         self.assertIn('endDate', auction['awards'][0]['complaintPeriod'])
         self.assertEqual(auction['status'], 'active.awarded')
 
-        response = self.app.post('/auctions/{}/contracts/{}/documents'.format(
-            self.auction_id, contract['id']), upload_files=[('file', 'name.doc', 'content')])
+        response = self.app.post('/auctions/{}/contracts/{}/documents?acc_token={}'.format(
+            self.auction_id, contract['id'], self.auction_token
+        ), upload_files=[('file', 'name.doc', 'content')])
         self.assertEqual(response.status, '201 Created')
         self.assertEqual(response.content_type, 'application/json')
 
-        response = self.app.patch_json('/auctions/{}/contracts/{}'.format(self.auction_id, auction['contracts'][0]['id']),
-                                       {"data": {"status": "active"}})
+        response = self.app.patch_json('/auctions/{}/contracts/{}?acc_token={}'.format(
+            self.auction_id, auction['contracts'][0]['id'], self.auction_token
+        ), {"data": {"status": "active"}})
         self.assertEqual(response.status, '200 OK')
         self.assertEqual(response.content_type, 'application/json')
         self.assertEqual(response.json['data']['status'], u'active')


### PR DESCRIPTION
Remove usage of 'admins' token in tests

### Depends on:

- https://github.com/openprocurement/openprocurement.auctions.core/pull/152